### PR TITLE
Update symfony to 3.2.4

### DIFF
--- a/.codenvy.dockerfile
+++ b/.codenvy.dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/stacksmith-images/minideb-buildpack:jessie-r8
+FROM gcr.io/stacksmith-images/minideb-buildpack:jessie-r9
 
 MAINTAINER Bitnami <containers@bitnami.com>
 
@@ -8,19 +8,19 @@ RUN install_packages git subversion openssh-server rsync
 RUN mkdir /var/run/sshd && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
 ENV BITNAMI_APP_NAME=che-symfony \
-    BITNAMI_IMAGE_VERSION=3.1.3-r12 \
+    BITNAMI_IMAGE_VERSION=3.2.4-r0 \
     PATH=/opt/bitnami/symfony:/opt/bitnami/php/bin:/opt/bitnami/mysql/bin/:$PATH
 
 # System packages required
-RUN install_packages libc6 zlib1g libxslt1.1 libtidy-0.99-0 libreadline6 libncurses5 libtinfo5 libmcrypt4 libldap-2.4-2 libstdc++6 libgmp10 libpng12-0 libjpeg62-turbo libbz2-1.0 libxml2 libssl1.0.0 libcurl3 libfreetype6 libicu52 libgcc1 libgcrypt20 libsasl2-2 libgnutls-deb0-28 liblzma5 libidn11 librtmp1 libssh2-1 libgssapi-krb5-2 libkrb5-3 libk5crypto3 libcomerr2 libgpg-error0 libp11-kit0 libtasn1-6 libnettle4 libhogweed2 libkrb5support0 libkeyutils1 libffi6 libjemalloc1
+RUN install_packages libc6 zlib1g libxslt1.1 libtidy-0.99-0 libreadline6 libncurses5 libtinfo5 libmcrypt4 libldap-2.4-2 libstdc++6 libgmp10 libpng12-0 libjpeg62-turbo libbz2-1.0 libxml2 libssl1.0.0 libcurl3 libfreetype6 libicu52 libgcc1 libgcrypt20 libsasl2-2 libgnutls-deb0-28 liblzma5 libidn11 librtmp1 libssh2-1 libgssapi-krb5-2 libkrb5-3 libk5crypto3 libcomerr2 libgpg-error0 libp11-kit0 libtasn1-6 libnettle4 libhogweed2 libkrb5support0 libkeyutils1 libffi6 libjemalloc1 libsybdb5 libpq5
 
 # Install Symfony dependencies
-RUN bitnami-pkg install php-7.0.15-4 --checksum 855e77fc7b87d1b263b08fdc96518c6fc301531923974917335f1cb8539d2a68
-RUN bitnami-pkg install mysql-client-10.1.21-0 --checksum 8e868a3e46bfa59f3fb4e1aae22fd9a95fd656c020614a64706106ba2eba224e
+RUN bitnami-pkg install php-7.0.16-0 --checksum f59c28b5c169aca61cde263facd6472f10b66d211f361f87cf8244b5d6f1e280
+RUN bitnami-pkg install mysql-client-10.1.21-1 --checksum 63155b08efa834316c47f29200a667f6d52506063dae861eb1edfba4266a9d62
 RUN bitnami-pkg install mariadb-10.1.21-0 --checksum ecf191e709c35881b69ff5aea22da984b6d05d4b751a0d5a72fa74bb02b71eea
 
 # Install Symfony module
-RUN bitnami-pkg install symfony-3.2.2-0 --checksum c67ef324d21969bd537f8012ddcb196ce293a6a07d680d34ad6b8402814fbdd7 -- --applicationDirectory /projects
+RUN bitnami-pkg install symfony-3.2.4-0 --checksum 5717ecd1f05745befa8ca0a746a5f11b0ed7a291e033350c001b616015ab6a5b -- --applicationDirectory /projects
 
 EXPOSE 8000
 

--- a/.codenvy.json
+++ b/.codenvy.json
@@ -5,7 +5,7 @@
       "default": {
         "recipe": {
           "type": "dockerimage",
-          "location": "bitnami/che-symfony:3.1.3-r12"
+          "location": "bitnami/che-symfony:3.2.4-r0"
         },
         "machines": {
           "ws-machine": {


### PR DESCRIPTION
This release includes several changes. Here is a list of the most important ones:
  - [VarDumper] Added missing persistent stream cast
  - [DependencyInjection] check for circular refs caused by method calls
  - [Serializer] fix upper camel case conversion
  - [Console][Table] fixed render when using multiple rowspans.
  - [Process] Permit empty suffix on Windows
  - [DI] Auto register extension configuration classes as a resource
  - Improve tracking of environment variables in the case of private services
  - [Validator] property constraints can be added in child classes
  - [Config] Early return for DirectoryResource
  - [DoctrineBridge] make sure that null can be the invalid value
  - [FrameworkBundle] Wire ArrayCache for annotation reader at bootstrap
  - [WebProfilerBundle] Readd Symfony version status in the toolbar
  - [VarDumper] Improve dump of AMQP* Object
  - [Security] LdapUserProvider should not throw an exception if the UID key does not exist in an LDAP entry
  - [FrameworkBundle] Fix annotations cache folder path
  - [VarDumper] Fixed dumping of terminated generator
  - Ignore missing 'debug.file_link_formatter' service in Debug bundle