### PR TITLE
Support Symfony 4

### DIFF
--- a/1/debian-9/Dockerfile
+++ b/1/debian-9/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/minideb-extras:stretch-r420
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
 # Install required system packages and dependencies
-RUN install_packages libbz2-1.0 libc6 libcomerr2 libcurl3 libffi6 libfreetype6 libgcc1 libgcrypt20 libgmp10 libgnutls30 libgpg-error0 libgssapi-krb5-2 libhogweed4 libicu57 libidn11 libidn2-0 libjpeg62-turbo libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmemcached11 libmemcachedutil2 libncurses5 libnettle6 libnghttp2-14 libp11-kit0 libpng16-16 libpq5 libpsl5 libreadline7 librtmp1 libsasl2-2 libssh2-1 libssl1.0.2 libssl1.1 libstdc++6 libsybdb5 libtasn1-6 libtidy5 libtinfo5 libunistring0 libxml2 libxslt1.1 libzip4 zlib1g
+RUN install_packages libbz2-1.0 libc6 libcomerr2 libcurl3 libffi6 libfreetype6 libgcc1 libgcrypt20 libgmp10 libgnutls30 libgpg-error0 libgssapi-krb5-2 libhogweed4 libicu57 libidn11 libidn2-0 libjpeg62-turbo libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmemcached11 libmemcachedutil2 libncurses5 libnettle6 libnghttp2-14 libp11-kit0 libpng16-16 libpq5 libpsl5 libreadline7 librtmp1 libsasl2-2 libssh2-1 libssl1.0.2 libssl1.1 libstdc++6 libsybdb5 libtasn1-6 libtidy5 libtinfo5 libunistring0 libxml2 libxslt1.1 libzip4 unzip zlib1g
 RUN bitnami-pkg unpack php-7.3.7-0 --checksum 706d0a7a939eaa105f6091e77ae72193b986297db5d03f3678099d8a419164c6
 RUN bitnami-pkg install mysql-client-10.3.16-0 --checksum c22e014b6fc259a67fcdd52b365e62ed08e6d7e6871888d9ef935c8531ada9b2
 RUN bitnami-pkg install symfony-1.5.11-20 --checksum e512f0bbcf6c8a6c01f87adcb8f193699a88db2f811986a65de2a0468c736fc8

--- a/1/debian-9/Dockerfile
+++ b/1/debian-9/Dockerfile
@@ -10,13 +10,13 @@ RUN bitnami-pkg install symfony-1.5.11-20 --checksum e512f0bbcf6c8a6c01f87adcb8f
 COPY rootfs /
 ENV BITNAMI_APP_NAME="symfony" \
     BITNAMI_IMAGE_VERSION="1.5.11-debian-9-r384" \
+    MARIADB_DATABASE="bitnami_myapp" \
     MARIADB_HOST="mariadb" \
     MARIADB_PORT_NUMBER="3306" \
     MARIADB_USER="root" \
-    MARIADB_DATABASE="bitnami_myapp" \
     PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/mysql/bin:/opt/bitnami/symfony/bin:$PATH" \
     SYMFONY_PROJECT_NAME="myapp" \
-    SYMFONY_SKIP_DB=
+    SYMFONY_SKIP_DB=""
 
 EXPOSE 8000
 

--- a/1/debian-9/Dockerfile
+++ b/1/debian-9/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/minideb-extras:stretch-r467
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
 # Install required system packages and dependencies
-RUN install_packages libbz2-1.0 libc6 libcomerr2 libcurl3 libffi6 libfreetype6 libgcc1 libgcrypt20 libgmp10 libgnutls30 libgpg-error0 libgssapi-krb5-2 libhogweed4 libicu57 libidn11 libidn2-0 libjpeg62-turbo libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmemcached11 libmemcachedutil2 libncurses5 libnettle6 libnghttp2-14 libp11-kit0 libpng16-16 libpq5 libpsl5 libreadline7 librtmp1 libsasl2-2 libssh2-1 libssl1.0.2 libssl1.1 libstdc++6 libsybdb5 libtasn1-6 libtidy5 libtinfo5 libunistring0 libxml2 libxslt1.1 libzip4 zlib1g
+RUN install_packages libbz2-1.0 libc6 libcomerr2 libcurl3 libffi6 libfreetype6 libgcc1 libgcrypt20 libgmp10 libgnutls30 libgpg-error0 libgssapi-krb5-2 libhogweed4 libicu57 libidn11 libidn2-0 libjpeg62-turbo libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmemcached11 libmemcachedutil2 libncurses5 libnettle6 libnghttp2-14 libp11-kit0 libpng16-16 libpq5 libpsl5 libreadline7 librtmp1 libsasl2-2 libssh2-1 libssl1.0.2 libssl1.1 libstdc++6 libsybdb5 libtasn1-6 libtidy5 libtinfo5 libunistring0 libxml2 libxslt1.1 libzip4 unzip zlib1g
 RUN bitnami-pkg unpack php-7.3.9-1 --checksum c82b1601abbb8cdff5b18d5c162cc04ad64f9582396378195341e43f71eac6a1
 RUN bitnami-pkg install mysql-client-10.3.17-0 --checksum 71d59fafc3e7e3e598af0c2b6788d77558630afe647ec1f922ffdd5025f3d737
 RUN bitnami-pkg install symfony-1.5.11-20 --checksum e512f0bbcf6c8a6c01f87adcb8f193699a88db2f811986a65de2a0468c736fc8
@@ -13,8 +13,10 @@ ENV BITNAMI_APP_NAME="symfony" \
     MARIADB_HOST="mariadb" \
     MARIADB_PORT_NUMBER="3306" \
     MARIADB_USER="root" \
+    MARIADB_DATABASE="bitnami_myapp" \
     PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/mysql/bin:/opt/bitnami/symfony/bin:$PATH" \
-    SYMFONY_PROJECT_NAME="myapp"
+    SYMFONY_PROJECT_NAME="myapp" \
+    SYMFONY_SKIP_DB=
 
 EXPOSE 8000
 

--- a/1/debian-9/Dockerfile
+++ b/1/debian-9/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/minideb-extras:stretch-r450
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
 # Install required system packages and dependencies
-RUN install_packages libbz2-1.0 libc6 libcomerr2 libcurl3 libffi6 libfreetype6 libgcc1 libgcrypt20 libgmp10 libgnutls30 libgpg-error0 libgssapi-krb5-2 libhogweed4 libicu57 libidn11 libidn2-0 libjpeg62-turbo libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmemcached11 libmemcachedutil2 libncurses5 libnettle6 libnghttp2-14 libp11-kit0 libpng16-16 libpq5 libpsl5 libreadline7 librtmp1 libsasl2-2 libssh2-1 libssl1.0.2 libssl1.1 libstdc++6 libsybdb5 libtasn1-6 libtidy5 libtinfo5 libunistring0 libxml2 libxslt1.1 libzip4 zlib1g
+RUN install_packages libbz2-1.0 libc6 libcomerr2 libcurl3 libffi6 libfreetype6 libgcc1 libgcrypt20 libgmp10 libgnutls30 libgpg-error0 libgssapi-krb5-2 libhogweed4 libicu57 libidn11 libidn2-0 libjpeg62-turbo libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmemcached11 libmemcachedutil2 libncurses5 libnettle6 libnghttp2-14 libp11-kit0 libpng16-16 libpq5 libpsl5 libreadline7 librtmp1 libsasl2-2 libssh2-1 libssl1.0.2 libssl1.1 libstdc++6 libsybdb5 libtasn1-6 libtidy5 libtinfo5 libunistring0 libxml2 libxslt1.1 libzip4 unzip zlib1g
 RUN bitnami-pkg unpack php-7.3.8-0 --checksum cc67ec3f4ff34c0f757e59e28b43572c4b20b938b84cd88a09a186dfd327abd0
 RUN bitnami-pkg install mysql-client-10.3.17-0 --checksum 71d59fafc3e7e3e598af0c2b6788d77558630afe647ec1f922ffdd5025f3d737
 RUN bitnami-pkg install symfony-1.5.11-20 --checksum e512f0bbcf6c8a6c01f87adcb8f193699a88db2f811986a65de2a0468c736fc8
@@ -10,9 +10,6 @@ RUN bitnami-pkg install symfony-1.5.11-20 --checksum e512f0bbcf6c8a6c01f87adcb8f
 COPY rootfs /
 ENV BITNAMI_APP_NAME="symfony" \
     BITNAMI_IMAGE_VERSION="1.5.11-debian-9-r364" \
-    MARIADB_HOST="mariadb" \
-    MARIADB_PORT_NUMBER="3306" \
-    MARIADB_USER="root" \
     PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/mysql/bin:/opt/bitnami/symfony/bin:$PATH" \
     SYMFONY_PROJECT_NAME="myapp"
 

--- a/1/debian-9/docker-compose.yml
+++ b/1/debian-9/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '2'
+
 services:
   myapp:
     image: 'bitnami/symfony:1'

--- a/1/debian-9/rootfs/app-entrypoint.sh
+++ b/1/debian-9/rootfs/app-entrypoint.sh
@@ -19,17 +19,17 @@ if [ "$1" = "/run.sh" ]; then
 
     composer create-project symfony/skeleton $SYMFONY_PROJECT_NAME
 
-    if [ ! -z "$SYMFONY_SKIP_DB" ] ; then
+    if [ -z "$SYMFONY_SKIP_DB" ] ; then
       log "Installing symfony/orm-pack"
       composer require symfony/orm-pack -d $PROJECT_DIRECTORY
 
-      export DATABASE_URL=mysql://$MARIADB_USER@$MARIADB_HOST/$MARIADB_DATABASE
-    fi
+      export DATABASE_URL="mysql://${MARIADB_USER}:${MARIADB_PASSWORD}@${MARIADB_HOST}:${MARIADB_PORT_NUMBER}/${MARIADB_DATABASE}"
 
-    if [ ! -f "$PROJECT_DIRECTORY/.env.local" ] ; then
-      touch $PROJECT_DIRECTORY/.env.local
-      echo "DATABASE_URL=$DATABASE_URL" >> $PROJECT_DIRECTORY/.env.local
-      log "Added MariaDB container credentials to .env.local"
+      if [ ! -f "$PROJECT_DIRECTORY/.env.local" ] ; then
+        touch $PROJECT_DIRECTORY/.env.local
+        echo "DATABASE_URL=$DATABASE_URL" >> $PROJECT_DIRECTORY/.env.local
+        log "Added MariaDB container credentials to .env.local"
+      fi
     fi
 
     log "Symfony app created"
@@ -44,7 +44,7 @@ if [ "$1" = "/run.sh" ]; then
 
   # Link Symfony app to the index
   if [ ! -f "$WEB_DIR/index.php" ] && [ -f "$WEB_DIR/app.php" ]; then
-    sudo ln -s "$WEB_DIR/app.php" "$WEB_DIR/web/index.php"
+    ln -s "$WEB_DIR/app.php" "$WEB_DIR/index.php"
   fi
 fi
 

--- a/1/debian-9/rootfs/app-entrypoint.sh
+++ b/1/debian-9/rootfs/app-entrypoint.sh
@@ -17,17 +17,17 @@ if [ "$1" = "/run.sh" ]; then
   if [ ! -d "$PROJECT_DIRECTORY" ] ; then
     log "Creating a project with symfony/skeleton"
 
-    composer create-project symfony/skeleton $SYMFONY_PROJECT_NAME
+    composer create-project symfony/skeleton "$SYMFONY_PROJECT_NAME"
 
     if [ -z "$SYMFONY_SKIP_DB" ] ; then
       log "Installing symfony/orm-pack"
-      composer require symfony/orm-pack -d $PROJECT_DIRECTORY
+      composer require symfony/orm-pack -d "$PROJECT_DIRECTORY"
 
-      export DATABASE_URL="mysql://${MARIADB_USER}:${MARIADB_PASSWORD}@${MARIADB_HOST}:${MARIADB_PORT_NUMBER}/${MARIADB_DATABASE}"
+      export DATABASE_URL="mysql://$MARIADB_USER:$MARIADB_PASSWORD@$MARIADB_HOST:$MARIADB_PORT_NUMBER/$MARIADB_DATABASE"
 
       if [ ! -f "$PROJECT_DIRECTORY/.env.local" ] ; then
-        touch $PROJECT_DIRECTORY/.env.local
-        echo "DATABASE_URL=$DATABASE_URL" >> $PROJECT_DIRECTORY/.env.local
+        touch "$PROJECT_DIRECTORY/.env.local"
+        echo "DATABASE_URL=$DATABASE_URL" >> "$PROJECT_DIRECTORY/.env.local"
         log "Added MariaDB container credentials to .env.local"
       fi
     fi
@@ -49,6 +49,7 @@ if [ "$1" = "/run.sh" ]; then
 fi
 
 echo "symfony successfully initialized"
+
   nami_initialize php
   info "Starting symfony... "
 fi

--- a/1/debian-9/rootfs/app-entrypoint.sh
+++ b/1/debian-9/rootfs/app-entrypoint.sh
@@ -22,9 +22,9 @@ if [ "$1" = "/run.sh" ]; then
     if [ ! -z "$SYMFONY_SKIP_DB" ] ; then
       log "Installing symfony/orm-pack"
       composer require symfony/orm-pack -d $PROJECT_DIRECTORY
-    fi
 
-    export DATABASE_URL=mysql://$MARIADB_USER@$MARIADB_HOST/$MARIADB_DATABASE
+      export DATABASE_URL=mysql://$MARIADB_USER@$MARIADB_HOST/$MARIADB_DATABASE
+    fi
 
     if [ ! -f "$PROJECT_DIRECTORY/.env.local" ] ; then
       touch $PROJECT_DIRECTORY/.env.local

--- a/1/debian-9/rootfs/app-entrypoint.sh
+++ b/1/debian-9/rootfs/app-entrypoint.sh
@@ -27,7 +27,7 @@ if [ "$1" = "/run.sh" ]; then
     export DATABASE_URL=mysql://$MARIADB_USER@$MARIADB_HOST/$MARIADB_DATABASE
 
     if [ ! -f "$PROJECT_DIRECTORY/.env.local" ] ; then
-      touch $PROJECT_DIRECTORY
+      touch $PROJECT_DIRECTORY/.env.local
       echo "DATABASE_URL=$DATABASE_URL" >> $PROJECT_DIRECTORY/.env.local
       log "Added MariaDB container credentials to .env.local"
     fi

--- a/1/debian-9/rootfs/app-entrypoint.sh
+++ b/1/debian-9/rootfs/app-entrypoint.sh
@@ -19,7 +19,7 @@ if [ "$1" = "/run.sh" ]; then
 
     composer create-project symfony/skeleton $SYMFONY_PROJECT_NAME
 
-    if [ -z "$SYMFONY_NO_DB" ] ; then
+    if [ ! -z "$SYMFONY_SKIP_DB" ] ; then
       log "Installing symfony/orm-pack"
       composer require symfony/orm-pack -d $PROJECT_DIRECTORY
     fi

--- a/1/debian-9/rootfs/run.sh
+++ b/1/debian-9/rootfs/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-php -S 0.0.0.0:8000 -t $PROJECT_DIRECTORY/web/
+php -S 0.0.0.0:8000 -t $WEB_DIR

--- a/1/debian-9/rootfs/run.sh
+++ b/1/debian-9/rootfs/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-php -S 0.0.0.0:8000 -t $WEB_DIR
+php -S 0.0.0.0:8000 -t "$WEB_DIR"

--- a/1/ol-7/Dockerfile
+++ b/1/ol-7/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/oraclelinux-extras:7-r400
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
 # Install required system packages and dependencies
-RUN install_packages bzip2-libs cyrus-sasl-lib freetds freetype glibc gmp gnutls keyutils-libs krb5-libs libcom_err libcurl libffi libgcc libgcrypt libgpg-error libicu libidn libjpeg-turbo libmemcached libpng libselinux libssh2 libstdc++ libtasn1 libtidy libxml2 libxslt ncurses-libs nettle nspr nss nss-softokn-freebl nss-util openldap openssl-libs p11-kit pcre postgresql-libs readline xz-libs zlib
+RUN install_packages bzip2-libs cyrus-sasl-lib freetds freetype glibc gmp gnutls keyutils-libs krb5-libs libcom_err libcurl libffi libgcc libgcrypt libgpg-error libicu libidn libjpeg-turbo libmemcached libpng libselinux libssh2 libstdc++ libtasn1 libtidy libxml2 libxslt ncurses-libs nettle nspr nss nss-softokn-freebl nss-util openldap openssl-libs p11-kit pcre postgresql-libs readline unzip xz-libs zlib
 RUN bitnami-pkg unpack php-7.3.7-0 --checksum 433c0d4c346ba1cc2c3e4a117c28acf418460e777863fb341c9be99a3b6afa87
 RUN bitnami-pkg install mysql-client-10.3.16-0 --checksum bc7ef5b2abef585c0079a7e4cb2a099c5f40cf39402c52078438a39882953ab4
 RUN bitnami-pkg install symfony-1.5.11-20 --checksum d4714f97e462524266a97626854747c743e1d4b5a9f9be155f480eef9b592631
@@ -10,11 +10,7 @@ RUN bitnami-pkg install symfony-1.5.11-20 --checksum d4714f97e462524266a97626854
 COPY rootfs /
 ENV BITNAMI_APP_NAME="symfony" \
     BITNAMI_IMAGE_VERSION="1.5.11-ol-7-r358" \
-    MARIADB_HOST="mariadb" \
-    MARIADB_PORT_NUMBER="3306" \
-    MARIADB_USER="root" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/mysql/bin:/opt/bitnami/symfony/bin:$PATH" \
-    SYMFONY_PROJECT_NAME="myapp"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/mysql/bin:/opt/bitnami/symfony/bin:$PATH"
 
 EXPOSE 8000
 

--- a/1/ol-7/Dockerfile
+++ b/1/ol-7/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/oraclelinux-extras:7-r451
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
 # Install required system packages and dependencies
-RUN install_packages bzip2-libs cyrus-sasl-lib freetds-libs freetype glibc gmp gnutls keyutils-libs krb5-libs libcom_err libcurl libffi libgcc libgcrypt libgpg-error libicu libidn libjpeg-turbo libmemcached libpng libselinux libssh2 libstdc++ libtasn1 libtidy libxml2 libxslt ncurses-libs nettle nspr nss nss-softokn-freebl nss-util openldap openssl-libs p11-kit pcre postgresql-libs readline xz-libs unzip zlib
+RUN install_packages bzip2-libs cyrus-sasl-lib freetds-libs freetype glibc gmp gnutls keyutils-libs krb5-libs libcom_err libcurl libffi libgcc libgcrypt libgpg-error libicu libidn libjpeg-turbo libmemcached libpng libselinux libssh2 libstdc++ libtasn1 libtidy libxml2 libxslt ncurses-libs nettle nspr nss nss-softokn-freebl nss-util openldap openssl-libs p11-kit pcre postgresql-libs readline unzip xz-libs zlib
 RUN bitnami-pkg unpack php-7.3.9-1 --checksum d12b49a00eb74dae3b46b4c5b57c9709e79e3157ddd26959c8ca08e919265bb7
 RUN bitnami-pkg install mysql-client-10.3.17-0 --checksum 83fd01acb88a54d028a327870cec66bf43f57f326814a16dc4626a5171742229
 RUN bitnami-pkg install symfony-1.5.11-20 --checksum d4714f97e462524266a97626854747c743e1d4b5a9f9be155f480eef9b592631
@@ -10,13 +10,13 @@ RUN bitnami-pkg install symfony-1.5.11-20 --checksum d4714f97e462524266a97626854
 COPY rootfs /
 ENV BITNAMI_APP_NAME="symfony" \
     BITNAMI_IMAGE_VERSION="1.5.11-ol-7-r408" \
+    MARIADB_DATABASE="bitnami_myapp" \
     MARIADB_HOST="mariadb" \
     MARIADB_PORT_NUMBER="3306" \
     MARIADB_USER="root" \
-    MARIADB_DATABASE="bitnami_myapp" \
     PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/mysql/bin:/opt/bitnami/symfony/bin:$PATH" \
     SYMFONY_PROJECT_NAME="myapp" \
-    SYMFONY_SKIP_DB=
+    SYMFONY_SKIP_DB=""
 
 EXPOSE 8000
 

--- a/1/ol-7/Dockerfile
+++ b/1/ol-7/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/oraclelinux-extras:7-r448
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
 # Install required system packages and dependencies
-RUN install_packages bzip2-libs cyrus-sasl-lib freetds-libs freetype glibc gmp gnutls keyutils-libs krb5-libs libcom_err libcurl libffi libgcc libgcrypt libgpg-error libicu libidn libjpeg-turbo libmemcached libpng libselinux libssh2 libstdc++ libtasn1 libtidy libxml2 libxslt ncurses-libs nettle nspr nss nss-softokn-freebl nss-util openldap openssl-libs p11-kit pcre postgresql-libs readline xz-libs zlib
+RUN install_packages bzip2-libs cyrus-sasl-lib freetds-libs freetype glibc gmp gnutls keyutils-libs krb5-libs libcom_err libcurl libffi libgcc libgcrypt libgpg-error libicu libidn libjpeg-turbo libmemcached libpng libselinux libssh2 libstdc++ libtasn1 libtidy libxml2 libxslt ncurses-libs nettle nspr nss nss-softokn-freebl nss-util openldap openssl-libs p11-kit pcre postgresql-libs readline xz-libs unzip zlib
 RUN bitnami-pkg unpack php-7.3.9-1 --checksum d12b49a00eb74dae3b46b4c5b57c9709e79e3157ddd26959c8ca08e919265bb7
 RUN bitnami-pkg install mysql-client-10.3.17-0 --checksum 83fd01acb88a54d028a327870cec66bf43f57f326814a16dc4626a5171742229
 RUN bitnami-pkg install symfony-1.5.11-20 --checksum d4714f97e462524266a97626854747c743e1d4b5a9f9be155f480eef9b592631
@@ -13,8 +13,10 @@ ENV BITNAMI_APP_NAME="symfony" \
     MARIADB_HOST="mariadb" \
     MARIADB_PORT_NUMBER="3306" \
     MARIADB_USER="root" \
+    MARIADB_DATABASE="bitnami_myapp" \
     PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/mysql/bin:/opt/bitnami/symfony/bin:$PATH" \
-    SYMFONY_PROJECT_NAME="myapp"
+    SYMFONY_PROJECT_NAME="myapp" \
+    SYMFONY_SKIP_DB=
 
 EXPOSE 8000
 

--- a/1/ol-7/Dockerfile
+++ b/1/ol-7/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/oraclelinux-extras:7-r430
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
 # Install required system packages and dependencies
-RUN install_packages bzip2-libs cyrus-sasl-lib freetds freetype glibc gmp gnutls keyutils-libs krb5-libs libcom_err libcurl libffi libgcc libgcrypt libgpg-error libicu libidn libjpeg-turbo libmemcached libpng libselinux libssh2 libstdc++ libtasn1 libtidy libxml2 libxslt ncurses-libs nettle nspr nss nss-softokn-freebl nss-util openldap openssl-libs p11-kit pcre postgresql-libs readline xz-libs zlib
+RUN install_packages bzip2-libs cyrus-sasl-lib freetds freetype glibc gmp gnutls keyutils-libs krb5-libs libcom_err libcurl libffi libgcc libgcrypt libgpg-error libicu libidn libjpeg-turbo libmemcached libpng libselinux libssh2 libstdc++ libtasn1 libtidy libxml2 libxslt ncurses-libs nettle nspr nss nss-softokn-freebl nss-util openldap openssl-libs p11-kit pcre postgresql-libs readline xz-libs unzip zlib
 RUN bitnami-pkg unpack php-7.3.8-0 --checksum 0cb38be663ea54976a58f46e1dd1201727a81798b88a5c5b2163c4c39921d32d
 RUN bitnami-pkg install mysql-client-10.3.17-0 --checksum 83fd01acb88a54d028a327870cec66bf43f57f326814a16dc4626a5171742229
 RUN bitnami-pkg install symfony-1.5.11-20 --checksum d4714f97e462524266a97626854747c743e1d4b5a9f9be155f480eef9b592631
@@ -10,9 +10,6 @@ RUN bitnami-pkg install symfony-1.5.11-20 --checksum d4714f97e462524266a97626854
 COPY rootfs /
 ENV BITNAMI_APP_NAME="symfony" \
     BITNAMI_IMAGE_VERSION="1.5.11-ol-7-r388" \
-    MARIADB_HOST="mariadb" \
-    MARIADB_PORT_NUMBER="3306" \
-    MARIADB_USER="root" \
     PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/mysql/bin:/opt/bitnami/symfony/bin:$PATH" \
     SYMFONY_PROJECT_NAME="myapp"
 

--- a/1/ol-7/docker-compose.yml
+++ b/1/ol-7/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '2'
+
 services:
   myapp:
     image: 'bitnami/symfony:1-ol-7'

--- a/1/ol-7/rootfs/app-entrypoint.sh
+++ b/1/ol-7/rootfs/app-entrypoint.sh
@@ -19,17 +19,17 @@ if [ "$1" = "/run.sh" ]; then
 
     composer create-project symfony/skeleton $SYMFONY_PROJECT_NAME
 
-    if [ ! -z "$SYMFONY_SKIP_DB" ] ; then
+    if [ -z "$SYMFONY_SKIP_DB" ] ; then
       log "Installing symfony/orm-pack"
       composer require symfony/orm-pack -d $PROJECT_DIRECTORY
 
-      export DATABASE_URL=mysql://$MARIADB_USER@$MARIADB_HOST/$MARIADB_DATABASE
-    fi
+      export DATABASE_URL="mysql://${MARIADB_USER}:${MARIADB_PASSWORD}@${MARIADB_HOST}:${MARIADB_PORT_NUMBER}/${MARIADB_DATABASE}"
 
-    if [ ! -f "$PROJECT_DIRECTORY/.env.local" ] ; then
-      touch $PROJECT_DIRECTORY/.env.local
-      echo "DATABASE_URL=$DATABASE_URL" >> $PROJECT_DIRECTORY/.env.local
-      log "Added MariaDB container credentials to .env.local"
+      if [ ! -f "$PROJECT_DIRECTORY/.env.local" ] ; then
+        touch $PROJECT_DIRECTORY/.env.local
+        echo "DATABASE_URL=$DATABASE_URL" >> $PROJECT_DIRECTORY/.env.local
+        log "Added MariaDB container credentials to .env.local"
+      fi
     fi
 
     log "Symfony app created"
@@ -44,7 +44,7 @@ if [ "$1" = "/run.sh" ]; then
 
   # Link Symfony app to the index
   if [ ! -f "$WEB_DIR/index.php" ] && [ -f "$WEB_DIR/app.php" ]; then
-    sudo ln -s "$WEB_DIR/app.php" "$WEB_DIR/web/index.php"
+    ln -s "$WEB_DIR/app.php" "$WEB_DIR/index.php"
   fi
 fi
 

--- a/1/ol-7/rootfs/app-entrypoint.sh
+++ b/1/ol-7/rootfs/app-entrypoint.sh
@@ -17,17 +17,17 @@ if [ "$1" = "/run.sh" ]; then
   if [ ! -d "$PROJECT_DIRECTORY" ] ; then
     log "Creating a project with symfony/skeleton"
 
-    composer create-project symfony/skeleton $SYMFONY_PROJECT_NAME
+    composer create-project symfony/skeleton "$SYMFONY_PROJECT_NAME"
 
     if [ -z "$SYMFONY_SKIP_DB" ] ; then
       log "Installing symfony/orm-pack"
-      composer require symfony/orm-pack -d $PROJECT_DIRECTORY
+      composer require symfony/orm-pack -d "$PROJECT_DIRECTORY"
 
-      export DATABASE_URL="mysql://${MARIADB_USER}:${MARIADB_PASSWORD}@${MARIADB_HOST}:${MARIADB_PORT_NUMBER}/${MARIADB_DATABASE}"
+      export DATABASE_URL="mysql://$MARIADB_USER:$MARIADB_PASSWORD@$MARIADB_HOST:$MARIADB_PORT_NUMBER/$MARIADB_DATABASE"
 
       if [ ! -f "$PROJECT_DIRECTORY/.env.local" ] ; then
-        touch $PROJECT_DIRECTORY/.env.local
-        echo "DATABASE_URL=$DATABASE_URL" >> $PROJECT_DIRECTORY/.env.local
+        touch "$PROJECT_DIRECTORY/.env.local"
+        echo "DATABASE_URL=$DATABASE_URL" >> "$PROJECT_DIRECTORY/.env.local"
         log "Added MariaDB container credentials to .env.local"
       fi
     fi
@@ -49,6 +49,7 @@ if [ "$1" = "/run.sh" ]; then
 fi
 
 echo "symfony successfully initialized"
+
   nami_initialize php
   info "Starting symfony... "
 fi

--- a/1/ol-7/rootfs/app-entrypoint.sh
+++ b/1/ol-7/rootfs/app-entrypoint.sh
@@ -22,9 +22,9 @@ if [ "$1" = "/run.sh" ]; then
     if [ ! -z "$SYMFONY_SKIP_DB" ] ; then
       log "Installing symfony/orm-pack"
       composer require symfony/orm-pack -d $PROJECT_DIRECTORY
-    fi
 
-    export DATABASE_URL=mysql://$MARIADB_USER@$MARIADB_HOST/$MARIADB_DATABASE
+      export DATABASE_URL=mysql://$MARIADB_USER@$MARIADB_HOST/$MARIADB_DATABASE
+    fi
 
     if [ ! -f "$PROJECT_DIRECTORY/.env.local" ] ; then
       touch $PROJECT_DIRECTORY/.env.local

--- a/1/ol-7/rootfs/app-entrypoint.sh
+++ b/1/ol-7/rootfs/app-entrypoint.sh
@@ -27,7 +27,7 @@ if [ "$1" = "/run.sh" ]; then
     export DATABASE_URL=mysql://$MARIADB_USER@$MARIADB_HOST/$MARIADB_DATABASE
 
     if [ ! -f "$PROJECT_DIRECTORY/.env.local" ] ; then
-      touch $PROJECT_DIRECTORY
+      touch $PROJECT_DIRECTORY/.env.local
       echo "DATABASE_URL=$DATABASE_URL" >> $PROJECT_DIRECTORY/.env.local
       log "Added MariaDB container credentials to .env.local"
     fi

--- a/1/ol-7/rootfs/app-entrypoint.sh
+++ b/1/ol-7/rootfs/app-entrypoint.sh
@@ -19,7 +19,7 @@ if [ "$1" = "/run.sh" ]; then
 
     composer create-project symfony/skeleton $SYMFONY_PROJECT_NAME
 
-    if [ -z "$SYMFONY_NO_DB" ] ; then
+    if [ ! -z "$SYMFONY_SKIP_DB" ] ; then
       log "Installing symfony/orm-pack"
       composer require symfony/orm-pack -d $PROJECT_DIRECTORY
     fi

--- a/1/ol-7/rootfs/run.sh
+++ b/1/ol-7/rootfs/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-php -S 0.0.0.0:8000 -t $PROJECT_DIRECTORY/web/
+php -S 0.0.0.0:8000 -t $WEB_DIR

--- a/1/ol-7/rootfs/run.sh
+++ b/1/ol-7/rootfs/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-php -S 0.0.0.0:8000 -t $WEB_DIR
+php -S 0.0.0.0:8000 -t "$WEB_DIR"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 
 # Bitnami Symfony Development Container
 
-> Note that this is a development container that includes the [`symfony` command-line tool](https://symfony.com/blog/introducing-the-new-symfony-installer).
-> This allows you to create a project based on any version of symfony.
+> Note that this is a development container. If a Symfony app is not already
+> present, `composer create-project symfony/skeleton $SYMFONY_PROJECT_NAME`
+> is run to create a Symfony 4.x project.
+>
+> In the absence of the `$SYMFONY_NO_DB,` envvar/flag, `symfony/orm-pack` is installed.
 
 ## TL;DR;
 
@@ -11,6 +14,8 @@
 ```bash
 $ mkdir ~/myapp && cd ~/myapp
 $ curl -LO https://raw.githubusercontent.com/bitnami/bitnami-docker-symfony/master/docker-compose.yml
+# Set some default envvars
+$ echo "SYMFONY_PROJECT_NAME=myapp\nMARIADB_HOST=mariadb\nMARIADB_PORT_NUMBER=3306\nMARIADB_USER=bobby\nMARIADB_PASSWORD=tables\nMARIADB_DATABASE=myapp" > .env
 $ docker-compose up
 ```
 
@@ -73,6 +78,12 @@ Download the [docker-compose.yml](https://raw.githubusercontent.com/bitnami/bitn
 
 ```bash
 $ curl -LO https://raw.githubusercontent.com/bitnami/bitnami-docker-symfony/master/docker-compose.yml
+```
+
+Set a few environment variables
+
+```bash
+$ echo "SYMFONY_PROJECT_NAME=myapp\nMARIADB_HOST=mariadb\nMARIADB_PORT_NUMBER=3306\nMARIADB_USER=bobby\nMARIADB_PASSWORD=tables\nMARIADB_DATABASE=myapp" > .env
 ```
 
 Finally launch the Symfony application development environment using:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 > present, `composer create-project symfony/skeleton $SYMFONY_PROJECT_NAME`
 > is run to create a Symfony 4.x project.
 >
-> Include a non null value in the `$SYMFONY_SKIP_DB,` envvar/flag, to skip over
-> installing `symfony/orm-pack`
+> Include a non null value in the `$SYMFONY_SKIP_DB` envvar/flag, to skip over
+> installing `symfony/orm-pack`.
 
 ## TL;DR;
 
@@ -15,8 +15,6 @@
 ```bash
 $ mkdir ~/myapp && cd ~/myapp
 $ curl -LO https://raw.githubusercontent.com/bitnami/bitnami-docker-symfony/master/docker-compose.yml
-# Set some default envvars
-$ echo "SYMFONY_PROJECT_NAME=myapp\nMARIADB_HOST=mariadb\nMARIADB_PORT_NUMBER=3306\nMARIADB_USER=bobby\nMARIADB_PASSWORD=tables\nMARIADB_DATABASE=myapp" > .env
 $ docker-compose up
 ```
 
@@ -81,10 +79,34 @@ Download the [docker-compose.yml](https://raw.githubusercontent.com/bitnami/bitn
 $ curl -LO https://raw.githubusercontent.com/bitnami/bitnami-docker-symfony/master/docker-compose.yml
 ```
 
-Set a few environment variables
+Set a few environment variables in the `docker-compose.yml`:
 
-```bash
-$ echo "SYMFONY_PROJECT_NAME=myapp\nMARIADB_HOST=mariadb\nMARIADB_PORT_NUMBER=3306\nMARIADB_USER=bobby\nMARIADB_PASSWORD=tables\nMARIADB_DATABASE=myapp" > .env
+```yaml
+version: '2'
+
+services:
+  myapp:
+    image: 'bitnami/symfony:1'
+    ports:
+      - '8000:8000'
+    volumes:
+      - '.:/app'
+    environment:
+      - SYMFONY_PROJECT_NAME=myapp
+      - MARIADB_HOST=mariadb
+      - MARIADB_PORT_NUMBER=3306
+      - MARIADB_USER=bobby
+      - MARIADB_PASSWORD=tables
+      - MARIADB_DATABASE=myapp
+    depends_on:
+      - mariadb
+  mariadb:
+    image: 'bitnami/mariadb:10.3'
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - MARIADB_USER=bobby
+      - MARIADB_PASSWORD=tables
+      - MARIADB_DATABASE=myapp
 ```
 
 Finally launch the Symfony application development environment using:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 > present, `composer create-project symfony/skeleton $SYMFONY_PROJECT_NAME`
 > is run to create a Symfony 4.x project.
 >
-> In the absence of the `$SYMFONY_NO_DB,` envvar/flag, `symfony/orm-pack` is installed.
+> Include a non null value in the `$SYMFONY_SKIP_DB,` envvar/flag, to skip over
+> installing `symfony/orm-pack`
 
 ## TL;DR;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '2'
+
 services:
   myapp:
     image: 'bitnami/symfony:1'
@@ -6,9 +7,11 @@ services:
       - '8000:8000'
     volumes:
       - '.:/app'
+    env_file:
+      - .env
     depends_on:
       - mariadb
   mariadb:
     image: 'bitnami/mariadb:10.3'
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
+    env_file:
+      - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,20 +7,9 @@ services:
       - '8000:8000'
     volumes:
       - '.:/app'
-    environment:
-      - SYMFONY_PROJECT_NAME=myapp
-      - MARIADB_HOST=mariadb
-      - MARIADB_PORT_NUMBER=3306
-      - MARIADB_USER=bobby
-      - MARIADB_PASSWORD=tables
-      - MARIADB_DATABASE=myapp
     depends_on:
       - mariadb
   mariadb:
     image: 'bitnami/mariadb:10.3'
     environment:
-      - MARIADB_PORT_NUMBER=3306
-      - MARIADB_USER=bobby
-      - MARIADB_PASSWORD=tables
-      - MARIADB_DATABASE=myapp
       - ALLOW_EMPTY_PASSWORD=yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,20 @@ services:
       - '8000:8000'
     volumes:
       - '.:/app'
-    env_file:
-      - .env
+    environment:
+      - SYMFONY_PROJECT_NAME=myapp
+      - MARIADB_HOST=mariadb
+      - MARIADB_PORT_NUMBER=3306
+      - MARIADB_USER=bobby
+      - MARIADB_PASSWORD=tables
+      - MARIADB_DATABASE=myapp
     depends_on:
       - mariadb
   mariadb:
     image: 'bitnami/mariadb:10.3'
-    env_file:
-      - .env
+    environment:
+      - MARIADB_PORT_NUMBER=3306
+      - MARIADB_USER=bobby
+      - MARIADB_PASSWORD=tables
+      - MARIADB_DATABASE=myapp
+      - ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Updates the default behaviour to install Symfony 4 via composer, rather than v3 through the now deprecated symfony cli tool. (Should we consider bumping the version of this image? Differences are substantial.)

If the `$PROJECT_DIR` is already present, and is SF3, this attempts to be compatible with it still.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

Version 4 of the Symfony framework. With this comes longer LTS scope and other improvements via SF4.

**Possible drawbacks**

Is opinionated, and keeps the mariadb image & uses `symfony/orm-pack` to put doctrine in, by default. Users can remove by putting a `SYMFONY_NO_DB` flag into `.env`.

<!-- Describe any known limitations with your change -->

**Applicable issues**

Haven't tested with SF3, but I'll do that and amend this when I can confirm.

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

Adds `unzip` as a dependency, for `composer`'s sake.

Moves `MARIADB_` envvars to a `.env` file, so that the symfony container can reference them not at build time like before, but at `up` time.

( References #63 )

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
